### PR TITLE
Add option break_at_newlines to be more like Gihub-flavoured Markdown

### DIFF
--- a/t/38_break_at_newlines.t
+++ b/t/38_break_at_newlines.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+BEGIN {
+    unless(eval q{ use Test::Differences; unified_diff; 1 }) {
+        note 'Test::Differences recommended';
+        *eq_or_diff = \&is_deeply;
+    }
+}
+
+use_ok('Text::MultiMarkdown', 'markdown');
+
+my $mkdn = <<'END';
+Newlines
+--------
+
+The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like
+content as real line breaks, which is probably what you intended.
+
+The next paragraph contains two phrases separated by a single newline character:
+
+    Roses are red
+    Violets are blue
+
+becomes
+
+Roses are red
+Violets are blue
+END
+
+{
+    my $m = Text::MultiMarkdown->new( break_at_newlines => 0 );
+
+    my $html = $m->markdown($mkdn);
+
+    eq_or_diff( $html, <<'EOF', 'off' );
+<h2 id="newlines">Newlines</h2>
+
+<p>The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like
+content as real line breaks, which is probably what you intended.</p>
+
+<p>The next paragraph contains two phrases separated by a single newline character:</p>
+
+<pre><code>Roses are red
+Violets are blue
+</code></pre>
+
+<p>becomes</p>
+
+<p>Roses are red
+Violets are blue</p>
+EOF
+}
+
+{
+    my $m = Text::MultiMarkdown->new( break_at_newlines => 1 );
+
+    my $html = $m->markdown($mkdn);
+
+    eq_or_diff( $html, <<'EOF', 'on');
+<h2 id="newlines">Newlines  </h2>
+
+<p>The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard <br />
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the <br />
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like <br />
+content as real line breaks, which is probably what you intended.</p>
+
+<p>The next paragraph contains two phrases separated by a single newline character:</p>
+
+<pre><code>Roses are red
+Violets are blue
+</code></pre>
+
+<p>becomes</p>
+
+<p>Roses are red <br />
+Violets are blue  </p>
+EOF
+}
+
+{
+    my $m = Text::MultiMarkdown->new();
+
+    my $html = $m->markdown($mkdn);
+
+    eq_or_diff( $html, <<'EOF', 'default' );
+<h2 id="newlines">Newlines</h2>
+
+<p>The biggest difference that GFM introduces is in the handling of linebreaks. With SM you can hard
+wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the
+cause of a huge number of unintentional formatting errors. GFM treats newlines in paragraph-like
+content as real line breaks, which is probably what you intended.</p>
+
+<p>The next paragraph contains two phrases separated by a single newline character:</p>
+
+<pre><code>Roses are red
+Violets are blue
+</code></pre>
+
+<p>becomes</p>
+
+<p>Roses are red
+Violets are blue</p>
+EOF
+}


### PR DESCRIPTION
This implements newline handling somewhat like the description of
Github-flavoured Markdown, described at http://github.github.com/github-flavored-markdown/

Normal markdown (and, until now, Text::MultiMarkdown) allows you
to hard-wrap text. Markdown will combine those lines into a single
paragraph of text. With break_at_newlines, Text::MultiMarkdown will
treat newlines in your text blocks as real line breaks.

The markdown

```
one
two
```

was once rendered as

```
<p>one
two</p>
```

which will be one paragraph in your browser - but with break_at_newlines,
will now be:

```
<p>one <br />
two  </p>
```

which will be two paragraphs in your browser.

The default for break_at_newlines is off.

This resolves GH #16.

Thanks to Clinton Gormley for coding this up - see bobtfish/text-markdown#15
