### PR TITLE
Metadata is properly encoded

### DIFF
--- a/lib/Text/MultiMarkdown.pm
+++ b/lib/Text/MultiMarkdown.pm
@@ -4,10 +4,11 @@ use strict;
 use warnings;
 use re 'eval';
 
-use Digest::MD5 qw(md5_hex);
-use Encode      qw();
-use Carp        qw(croak);
-use base        qw(Text::Markdown);
+use Digest::MD5    qw(md5_hex);
+use Encode         qw();
+use Carp           qw(croak);
+use base           qw(Text::Markdown);
+use HTML::Entities qw(encode_entities);
 
 our $VERSION   = '1.000034'; # 1.0.34
 $VERSION = eval $VERSION;
@@ -857,7 +858,7 @@ sub _xhtmlMetaData {
 
     foreach my $key (sort keys %{$self->{_metadata}} ) {
         if (lc($key) eq "title") {
-            $result.= "\t\t<title>$self->{_metadata}{$key}</title>\n";
+            $result.= "\t\t<title>" . encode_entities($self->{_metadata}{$key}) . "</title>\n";
         }
         elsif (lc($key) eq "css") {
             $result.= qq[\t\t<link type="text/css" rel="stylesheet" href="$self->{_metadata}{$key}"$self->{empty_element_suffix}\n];
@@ -866,7 +867,8 @@ sub _xhtmlMetaData {
 			$result .= qq[\t\t$self->{_metadata}{$key}\n]
 		}
         else {
-            $result.= qq[\t\t<meta name="$key" content="$self->{_metadata}{$key}"$self->{empty_element_suffix}\n];
+            $result.= qq[\t\t<meta name="] . encode_entities($key) . qq[" ]
+                . qq[content="] . encode_entities($self->{_metadata}{$key}) . qq["$self->{empty_element_suffix}\n];
         }
     }
     $result.= "\t</head>\n";

--- a/t/Text-MultiMarkdown.mdtest/XHTML_Headers.text
+++ b/t/Text-MultiMarkdown.mdtest/XHTML_Headers.text
@@ -1,5 +1,6 @@
-Title: MultiMarkdown Test Document
-Author: Fletcher T. Penney, MD
+Title: MultiMarkdown Test & Document
+Author: Fletcher T. Penney, MD & others
+Email: John "Bull" Doe <john.bull.doe@example.org>
 Date: January 14, 2006
 Format: complete
 Css: http://some.url/sample.css

--- a/t/Text-MultiMarkdown.mdtest/XHTML_Headers.xhtml
+++ b/t/Text-MultiMarkdown.mdtest/XHTML_Headers.xhtml
@@ -1,11 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
 	<head>
-		<meta name="Author" content="Fletcher T. Penney, MD" />
+		<meta name="Author" content="Fletcher T. Penney, MD &amp; others" />
 		<link type="text/css" rel="stylesheet" href="http://some.url/sample.css" />
 		<meta name="Date" content="January 14, 2006" />
+		<meta name="Email" content="John &quot;Bull&quot; Doe &lt;john.bull.doe@example.org&gt;" />
 		<meta name="Format" content="complete" />
-		<title>MultiMarkdown Test Document</title>
+		<title>MultiMarkdown Test &amp; Document</title>
 		<link rel="openid.server" href="http://www.myopenid.com/server" /> 
 <link rel="openid.delegate" href="http://openid.org/example" />
 	</head>


### PR DESCRIPTION
Special characters (like agnles, ampersand, or quotes) in metadata should be properly encoded,
or result will be invalid (X)HTML. Previous version passes metadata into result as-is. This change
applies encoding.

Existing test XHTML_Headers is modified to use few special characters in metadata.

All tests pass.
