### PR TITLE
self_url - The document url is prepended to the "#" anchor of footnotes.

### DIFF
--- a/README
+++ b/README
@@ -119,6 +119,7 @@ OPTIONS
     document_format
     use_wikilinks
     base_url
+    self_url - The document url is prepended to the "#" anchor of footnotes.
 
 METADATA
     MultiMarkdown supports the concept of 'metadata', which allows you to

--- a/lib/Text/MultiMarkdown.pm
+++ b/lib/Text/MultiMarkdown.pm
@@ -54,7 +54,7 @@ specifically to serve as a front-end to (X)HTML. You can use span-level
 HTML tags anywhere in a Markdown document, and you can use block level
 HTML tags (C<< <div> >>, C<< <table> >> etc.). Note that by default
 Markdown isn't interpreted in HTML block-level elements, unless you add
-a C<markdown=1"> attribute to the element. See L<Text::Markdown> for 
+a C<markdown=1"> attribute to the element. See L<Text::Markdown> for
 details.
 
 This module implements the MultiMarkdown markdown syntax extensions from:
@@ -151,6 +151,8 @@ Metadata options supported are:
 
 =item base_url
 
+=item self_url - The document url is prepended to the "#" anchor of footnotes.
+
 =back
 
 =head1 METADATA
@@ -228,6 +230,8 @@ sub new {
     $p{img_ids}     = defined $p{img_ids}     ? $p{img_ids}     : 1;
 
     $p{bibliography_title} ||= 'Bibliography'; # FIXME - Test and document, can also be in metadata!
+
+    $p{self_url} ||= ''; # Used in footnotes to prepend anchors
 
     my $self = { params => \%p };
     bless $self, ref($class) || $class;
@@ -758,10 +762,10 @@ sub _DoFootnotes {
         if (defined $self->{_footnotes}{$id} ) {
             $footnote_counter++;
             if ($self->{_footnotes}{$id} =~ /^glossary:/i) {
-                $result = qq{<a href="#fn:$id" id="fnref:$id" class="footnote glossary">$footnote_counter</a>};
+                $result = qq{<a href="$self->{self_url}#fn:$id" id="fnref:$id" class="footnote glossary">$footnote_counter</a>};
             }
             else {
-                $result = qq{<a href="#fn:$id" id="fnref:$id" class="footnote">$footnote_counter</a>};
+                $result = qq{<a href="$self->{self_url}#fn:$id" id="fnref:$id" class="footnote">$footnote_counter</a>};
             }
             push (@{ $self->{_used_footnotes} }, $id);
         }
@@ -811,10 +815,10 @@ sub _PrintFootnotes {
                 $glossary . q{:<p>};
             }egsx;
 
-            $result .= qq{<li id="fn:$id">$footnote<a href="#fnref:$id" class="reversefootnote">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n};
+            $result .= qq{<li id="fn:$id">$footnote<a href="$self->{self_url}#fnref:$id" class="reversefootnote">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n};
         }
         else {
-            $result .= qq{<li id="fn:$id">$footnote<a href="#fnref:$id" class="reversefootnote">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n};
+            $result .= qq{<li id="fn:$id">$footnote<a href="$self->{self_url}#fnref:$id" class="reversefootnote">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n};
         }
     }
 

--- a/t/38self_url.t
+++ b/t/38self_url.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use_ok( 'Text::MultiMarkdown');
+
+my $instr = <<TXT;
+A trivial block[^block] of text with footnote containing self_url.
+
+[^block]:  See http://example.com
+
+TXT
+
+my $m = Text::MultiMarkdown->new(
+    self_url => 'self_url.html',
+);
+my $outstr = <<TXT;
+<p>A trivial block<a href="self_url.html#fn:block" id="fnref:block" class="footnote">1</a> of text with footnote containing self_url.</p>
+
+<div class="footnotes">
+<hr />
+<ol>
+
+<li id="fn:block"><p>See http://example.com<a href="self_url.html#fnref:block" class="reversefootnote">&#160;&#8617;</a></p></li>
+
+</ol>
+</div>
+TXT
+
+is(
+    $m->markdown($instr) => $outstr,
+    'Markdown with self_url footnotes'
+);


### PR DESCRIPTION
Hi Tomas,
When the HTML is generated and put into a web page, the footnotes do not work always properly.
This happens when the HTML page uses the &lt;base /&gt; tag. for such cases the self_url containing the link to the page solves this problem.
I monkey-patched Text::MultiMarkdown in my project http://git.io/hvWSHQ, but would prefer to get rid of the patch :).
Regards,
